### PR TITLE
Fix trace of p.bclr and p.bset instructions

### DIFF
--- a/include/riscv_tracer_defines.sv
+++ b/include/riscv_tracer_defines.sv
@@ -74,8 +74,8 @@ parameter INSTR_PMAXU    =  { 7'b0000010, 10'b?, 3'b111, 5'b?, OPCODE_OP }; // p
 parameter INSTR_PBEXT    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_OP }; // pulp specific
 parameter INSTR_PBEXTU   =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_OP }; // pulp specific
 parameter INSTR_PBINS    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_OP }; // pulp specific
-parameter INSTR_PBCLR    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_OP }; // pulp specific
-parameter INSTR_PBSET    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_OP }; // pulp specific
+parameter INSTR_PBCLR    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_OP }; // pulp specific
+parameter INSTR_PBSET    =  { 2'b11, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_OP }; // pulp specific
 // FENCE
 parameter INSTR_FENCE    =  { 4'b0, 8'b?, 13'b0, OPCODE_FENCE };
 parameter INSTR_FENCEI   =  { 17'b0, 3'b001, 5'b0, OPCODE_FENCE };


### PR DESCRIPTION
When these instructions were implemented in e423b2c197dbed08968a6ddcf8356388e07b5f30, their effective `funct3` fields were accidentally switched. This was partially fixed in 7e07801be183f665e382a0667599ec34a9fc484b, but the tracer still had them wrong. This single commit PR fixes that.

By the way, I noted that these instructions are not documented in the datasheet under `docs`. The online [User Manual](http://www.pulp-platform.org/wp-content/uploads/2017/02/ri5cy_user_manual.pdf) has an additional chapter (Chapter 13: Instruction Set Extensions). Shouldn't that be included here?