### PR TITLE
Add Verilator model

### DIFF
--- a/verilator-model/.gitignore
+++ b/verilator-model/.gitignore
@@ -1,0 +1,5 @@
+# Verilator object directory
+obj_dir/
+# Test bench build objects
+testbench
+testbench.o

--- a/verilator-model/Makefile
+++ b/verilator-model/Makefile
@@ -1,0 +1,112 @@
+# Copyright 2017 Embecosm Limited <www.embecosm.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makefile for Verilator model of RI5CY
+# Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+# Tools
+
+VERILATOR = verilator
+VDIR = obj_dir
+CPPFLAGS = -I$(VDIR) `pkg-config --cflags verilator`
+CXXFLAGS = -Wall -Werror -std=c++11
+CXX = g++
+LD = g++
+
+# Testbench
+
+SRC = testbench.cpp
+
+OBJS = testbench.o
+
+EXE = testbench
+
+# top module name
+
+TOP = top
+
+# Verilator elements
+
+VSRC = cluster_clock_gating.sv            \
+       dp_ram.sv                          \
+       ram.sv                             \
+       top.sv                             \
+       ../include/apu_core_package.sv     \
+       ../include/riscv_defines.sv        \
+       ../include/riscv_tracer_defines.sv \
+       ../riscv_alu.sv                    \
+       ../riscv_alu_basic.sv              \
+       ../riscv_alu_div.sv                \
+       ../riscv_compressed_decoder.sv     \
+       ../riscv_controller.sv             \
+       ../riscv_cs_registers.sv           \
+       ../riscv_debug_unit.sv             \
+       ../riscv_decoder.sv                \
+       ../riscv_int_controller.sv         \
+       ../riscv_ex_stage.sv               \
+       ../riscv_hwloop_controller.sv      \
+       ../riscv_hwloop_regs.sv            \
+       ../riscv_id_stage.sv               \
+       ../riscv_if_stage.sv               \
+       ../riscv_load_store_unit.sv        \
+       ../riscv_mult.sv                   \
+       ../riscv_prefetch_buffer.sv        \
+       ../riscv_prefetch_L0_buffer.sv     \
+       ../riscv_register_file.sv          \
+       ../riscv_core.sv                   \
+       ../riscv_apu_disp.sv               \
+       ../riscv_L0_buffer.sv
+
+VINC = ../include
+
+VOBJS = $(VDIR)/verilated.o       \
+        $(VDIR)/verilated_vcd_c.o
+
+VLIB = $(VDIR)/V$(TOP)__ALL.a
+
+VSMK = V$(TOP).mk
+VMK  = $(VDIR)/$(VSMK)
+
+# Build the executable
+
+$(EXE): $(VLIB) $(VOBJS) $(OBJS)
+	$(LD) -o $@ $(OBJS) $(VLIB) $(VOBJS)
+
+$(VOBJS): $(VMK)
+	for f in $@; \
+	do \
+		sf=$$(basename $$f); \
+		$(MAKE) -C $(VDIR) -f $(VSMK) $$sf; \
+	done
+
+$(VLIB): $(VMK)
+	make -C $(VDIR) -f V$(TOP).mk
+
+$(VDIR)/$(TOP): $(VDIR) $(VMK)
+	$(MAKE) -C $(VDIR) -f $(VSMK)
+
+$(VDIR):
+	mkdir -p $@
+
+$(VMK): $(VSRC)
+	verilator -O3 -CFLAGS "-O3 -g3 -std=gnu++11" \
+                  -Wno-CASEINCOMPLETE -Wno-LITENDIAN -Wno-UNOPT \
+	          -Wno-UNOPTFLAT -Wno-WIDTH -Wno-fatal --top-module top \
+	          --Mdir $(VDIR) --trace -DPULP_FPGA_EMUL -cc \
+	          +incdir+$(VINC) $(VSRC) $(SRC) --exe
+
+.PHONY: clean
+clean:
+	$(RM) -r $(VDIR)
+	$(RM) $(EXE) $(OBJS)

--- a/verilator-model/README.md
+++ b/verilator-model/README.md
@@ -1,0 +1,66 @@
+RI5CY Verilator Model
+=====================
+
+The Verilator model of RI5CY instantiates the RI5CY core along with a RAM. A
+testbench accompanies the model, to demonstrate the use of the Verilated model.
+
+Building the model
+------------------
+
+In order to build the model, you will require a recent version of Verilator
+(3.906 or above), and that version of verilator must be known to pkg-config.
+
+Run `make` in the `verilator-model` directory to build the model.
+
+The Testbench
+-------------
+
+The testbench demonstrates:
+
+- Instantiating the model
+- Writing data to memory (a short program)
+- Resetting the CPU
+- Running the CPU
+- Using the debug unit to halt, set traps on exceptions, single-step, and
+  resume.
+
+The testbench can be executed as `./testbench`. The expected output of the
+testbench is:
+
+```
+About to halt and set traps on exceptions
+About to resume
+Cycling clock to run for a few instructions
+Halting
+Halted. Setting single step
+DBG_CTRL  10001
+DBG_HIT   0
+DBG_CAUSE 1f
+DBG_NPC   cc
+DBG_PPC   c8
+About to do one single step
+DBG_CTRL  10001
+DBG_HIT   1
+DBG_CAUSE 0
+DBG_NPC   d0
+DBG_PPC   cc
+About to do one single step
+DBG_CTRL  10001
+DBG_HIT   1
+DBG_CAUSE 0
+DBG_NPC   d4
+DBG_PPC   d0
+About to do one single step
+DBG_CTRL  10001
+DBG_HIT   1
+DBG_CAUSE 0
+DBG_NPC   d8
+DBG_PPC   d4
+About to do one single step
+DBG_CTRL  10001
+DBG_HIT   1
+DBG_CAUSE 0
+DBG_NPC   dc
+DBG_PPC   d8
+About to do one single step
+```

--- a/verilator-model/cluster_clock_gating.sv
+++ b/verilator-model/cluster_clock_gating.sv
@@ -1,0 +1,34 @@
+// Copyright 2017 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+module cluster_clock_gating
+(
+    input  logic clk_i,
+    input  logic en_i,
+    input  logic test_en_i,
+    output logic clk_o
+  );
+
+`ifdef PULP_FPGA_EMUL
+  // no clock gates in FPGA flow
+  assign clk_o = clk_i;
+`else
+  logic clk_en;
+
+  always_latch
+  begin
+     if (clk_i == 1'b0)
+       clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+`endif
+
+endmodule // cluster_clock_gating

--- a/verilator-model/dp_ram.sv
+++ b/verilator-model/dp_ram.sv
@@ -1,0 +1,68 @@
+// Copyright 2015 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+module dp_ram
+  #(
+    parameter ADDR_WIDTH = 8
+  )(
+    // Clock and Reset
+    input  logic clk,
+
+    input  logic                   en_a_i,
+    input  logic [ADDR_WIDTH-1:0]  addr_a_i,
+    input  logic [31:0]            wdata_a_i,
+    output logic [31:0]            rdata_a_o,
+    input  logic                   we_a_i,
+    input  logic [3:0]             be_a_i,
+
+    input  logic                   en_b_i,
+    input  logic [ADDR_WIDTH-1:0]  addr_b_i,
+    input  logic [31:0]            wdata_b_i,
+    output logic [31:0]            rdata_b_o,
+    input  logic                   we_b_i,
+    input  logic [3:0]             be_b_i
+  );
+
+  localparam words = 2**ADDR_WIDTH;
+
+  logic [3:0][7:0] mem[words];
+
+  always @(posedge clk)
+  begin
+    if (en_a_i && we_a_i)
+    begin
+      if (be_a_i[0])
+        mem[addr_a_i][0] <= wdata_a_i[7:0];
+      if (be_a_i[1])
+        mem[addr_a_i][1] <= wdata_a_i[15:8];
+      if (be_a_i[2])
+        mem[addr_a_i][2] <= wdata_a_i[23:16];
+      if (be_a_i[3])
+        mem[addr_a_i][3] <= wdata_a_i[31:24];
+    end
+
+    rdata_a_o <= mem[addr_a_i];
+
+    if (en_b_i && we_b_i)
+    begin
+      if (be_b_i[0])
+        mem[addr_b_i][0] <= wdata_b_i[7:0];
+      if (be_b_i[1])
+        mem[addr_b_i][1] <= wdata_b_i[15:8];
+      if (be_b_i[2])
+        mem[addr_b_i][2] <= wdata_b_i[23:16];
+      if (be_b_i[3])
+        mem[addr_b_i][3] <= wdata_b_i[31:24];
+    end
+
+    rdata_b_o <= mem[addr_b_i];
+  end
+
+endmodule

--- a/verilator-model/dp_ram.sv
+++ b/verilator-model/dp_ram.sv
@@ -1,4 +1,5 @@
 // Copyright 2015 ETH Zurich and University of Bologna.
+// Copyright 2017 Embecosm Limited <www.embecosm.com>
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the “License”); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at
@@ -18,7 +19,7 @@ module dp_ram
     input  logic                   en_a_i,
     input  logic [ADDR_WIDTH-1:0]  addr_a_i,
     input  logic [31:0]            wdata_a_i,
-    output logic [31:0]            rdata_a_o,
+    output logic [127:0]           rdata_a_o,
     input  logic                   we_a_i,
     input  logic [3:0]             be_a_i,
 
@@ -30,39 +31,67 @@ module dp_ram
     input  logic [3:0]             be_b_i
   );
 
-  localparam words = 2**ADDR_WIDTH;
+  localparam bytes = 2**ADDR_WIDTH;
 
-  logic [3:0][7:0] mem[words];
+  logic [7:0] mem[bytes];
+  logic [19:0] addr_b_int;
+
+  always_comb addr_b_int = {addr_b_i[19:2], 2'b0};
 
   always @(posedge clk)
   begin
-    if (en_a_i && we_a_i)
+
+    rdata_a_o[  0+: 8] <= mem[addr_a_i +  0];
+    rdata_a_o[  8+: 8] <= mem[addr_a_i +  1];
+    rdata_a_o[ 16+: 8] <= mem[addr_a_i +  2];
+    rdata_a_o[ 24+: 8] <= mem[addr_a_i +  3];
+    rdata_a_o[ 32+: 8] <= mem[addr_a_i +  4];
+    rdata_a_o[ 40+: 8] <= mem[addr_a_i +  5];
+    rdata_a_o[ 48+: 8] <= mem[addr_a_i +  6];
+    rdata_a_o[ 56+: 8] <= mem[addr_a_i +  7];
+    rdata_a_o[ 64+: 8] <= mem[addr_a_i +  8];
+    rdata_a_o[ 72+: 8] <= mem[addr_a_i +  9];
+    rdata_a_o[ 80+: 8] <= mem[addr_a_i + 10];
+    rdata_a_o[ 88+: 8] <= mem[addr_a_i + 11];
+    rdata_a_o[ 96+: 8] <= mem[addr_a_i + 12];
+    rdata_a_o[104+: 8] <= mem[addr_a_i + 13];
+    rdata_a_o[112+: 8] <= mem[addr_a_i + 14];
+    rdata_a_o[120+: 8] <= mem[addr_a_i + 15];
+
+    /* addr_b_i is the actual memory address referenced */
+
+    if (en_b_i)
     begin
-      if (be_a_i[0])
-        mem[addr_a_i][0] <= wdata_a_i[7:0];
-      if (be_a_i[1])
-        mem[addr_a_i][1] <= wdata_a_i[15:8];
-      if (be_a_i[2])
-        mem[addr_a_i][2] <= wdata_a_i[23:16];
-      if (be_a_i[3])
-        mem[addr_a_i][3] <= wdata_a_i[31:24];
+      /* handle writes */
+      if (we_b_i)
+      begin
+        if (be_b_i[0]) mem[addr_b_int    ] <= wdata_b_i[ 0+:8];
+        if (be_b_i[1]) mem[addr_b_int + 1] <= wdata_b_i[ 8+:8];
+        if (be_b_i[2]) mem[addr_b_int + 2] <= wdata_b_i[16+:8];
+        if (be_b_i[3]) mem[addr_b_int + 3] <= wdata_b_i[24+:8];
+      end
+      /* handle reads */
+      else
+      begin
+        rdata_b_o[ 7: 0] <= mem[addr_b_int    ];
+        rdata_b_o[15: 8] <= mem[addr_b_int + 1];
+        rdata_b_o[23:16] <= mem[addr_b_int + 2];
+        rdata_b_o[31:24] <= mem[addr_b_int + 3];
+      end
     end
-
-    rdata_a_o <= mem[addr_a_i];
-
-    if (en_b_i && we_b_i)
-    begin
-      if (be_b_i[0])
-        mem[addr_b_i][0] <= wdata_b_i[7:0];
-      if (be_b_i[1])
-        mem[addr_b_i][1] <= wdata_b_i[15:8];
-      if (be_b_i[2])
-        mem[addr_b_i][2] <= wdata_b_i[23:16];
-      if (be_b_i[3])
-        mem[addr_b_i][3] <= wdata_b_i[31:24];
-    end
-
-    rdata_b_o <= mem[addr_b_i];
   end
+
+  function [7:0] readByte;
+    /* verilator public */
+    input integer byte_addr;
+    readByte = mem[byte_addr];
+  endfunction
+
+  task writeByte;
+    /* verilator public */
+    input integer byte_addr;
+    input [7:0] val;
+    mem[byte_addr] = val;
+  endtask
 
 endmodule

--- a/verilator-model/ram.sv
+++ b/verilator-model/ram.sv
@@ -1,0 +1,74 @@
+// Copyright 2017 Embecosm Limited <www.embecosm.com>
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// RAM wrapper for RI5CY
+// Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+//
+// This maps the dp_ram module to the instruction and data ports of the RI5CY
+// processor core.
+
+module ram
+    #(
+    parameter ADDR_WIDTH = 22
+  )(
+    // Clock
+    input  logic                   clk,
+
+    input  logic                   instr_req_i,
+    input  logic [ADDR_WIDTH-1:0]  instr_addr_i,
+    output logic [127:0]           instr_rdata_o,
+    output logic                   instr_rvalid_o,
+    output logic                   instr_gnt_o,
+
+    input  logic                   data_req_i,
+    input  logic [ADDR_WIDTH-1:0]  data_addr_i,
+    input  logic                   data_we_i,
+    input  logic [3:0]             data_be_i,
+    input  logic [31:0]            data_wdata_i,
+    output logic [31:0]            data_rdata_o,
+    output logic                   data_rvalid_o,
+    output logic                   data_gnt_o
+  );
+
+   // Instantiate the ram
+
+   dp_ram
+     #(
+       .ADDR_WIDTH (ADDR_WIDTH)
+       )
+   dp_ram_i
+     (
+      .clk       ( clk           ),
+
+      .en_a_i    ( instr_req_i   ),
+      .addr_a_i  ( instr_addr_i  ),
+      .wdata_a_i ( '0            ),	// Not writing so ignored
+      .rdata_a_o ( instr_rdata_o ),
+      .we_a_i    ( '0            ),
+      .be_a_i    ( 4'b1111       ),	// Always want 32-bits
+
+      .en_b_i    ( data_req_i    ),
+      .addr_b_i  ( data_addr_i   ),
+      .wdata_b_i ( data_wdata_i  ),
+      .rdata_b_o ( data_rdata_o  ),
+      .we_b_i    ( data_we_i     ),
+      .be_b_i    ( data_be_i     )
+      );
+
+   assign data_gnt_o  = data_req_i;
+   assign instr_gnt_o = instr_req_i;
+
+   always_ff @(posedge clk)
+     begin
+	data_rvalid_o  <= data_req_i;
+	instr_rvalid_o <= instr_req_i;
+     end
+
+endmodule	// ram

--- a/verilator-model/testbench.cpp
+++ b/verilator-model/testbench.cpp
@@ -1,0 +1,307 @@
+// Copyright 2017 Embecosm Limited <www.embecosm.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simple Verilator model test bench
+// Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+// Contributor Graham Markall <graham.markall@embecosm.com>
+
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+#include "Vtop.h"
+#include "Vtop__Syms.h"
+
+#include <iostream>
+#include <cstdint>
+#include <cstdlib>
+
+using std::cout;
+using std::cerr;
+using std::endl;
+
+// Count of clock ticks
+
+static vluint64_t  cpuTime = 0;
+
+// Debug registers
+
+const uint16_t DBG_CTRL    = 0x0000;  //!< Debug control
+const uint16_t DBG_HIT     = 0x0004;  //!< Debug hit
+const uint16_t DBG_IE      = 0x0008;  //!< Debug interrupt enable
+const uint16_t DBG_CAUSE   = 0x000c;  //!< Debug cause (why entered debug)
+const uint16_t DBG_GPR0    = 0x0400;  //!< General purpose register 0
+const uint16_t DBG_GPR31   = 0x047c;  //!< General purpose register 41
+const uint16_t DBG_NPC     = 0x2000;  //!< Next PC
+const uint16_t DBG_PPC     = 0x2004;  //!< Prev PC
+
+// Debug register flags
+
+const uint32_t DBG_CTRL_HALT = 0x00010000;    //!< Halt core
+const uint32_t DBG_CTRL_SSTE = 0x00000001;    //!< Single step core
+
+static uint64_t mCycleCnt = 0;
+
+Vtop *cpu;
+VerilatedVcdC * tfp;
+
+// Clock the CPU for a given number of cycles, dumping to the trace file at
+// each clock edge.
+void clockSpin(uint32_t cycles)
+{
+  for (uint32_t i = 0; i < cycles; i++)
+  {
+      cpu->clk_i = 0;
+      cpu->eval ();
+      cpuTime += 5;
+      tfp->dump (cpuTime);
+      cpu->clk_i = 1;
+      cpu->eval ();
+      cpuTime += 5;
+      tfp->dump (cpuTime);
+      mCycleCnt++;
+  }
+}
+
+// Read/write a debug register.
+void debugAccess(uint32_t addr, uint32_t& val, bool write_enable)
+{
+  cpu->debug_req_i   = 1;
+  cpu->debug_addr_i  = addr;
+  cpu->debug_we_i    = write_enable ? 1 : 0;
+
+  if (write_enable)
+  {
+    cpu->debug_wdata_i = val;
+  }
+
+  // Access has been acknowledged when we get the grant signal asserted.
+  do
+    {
+      clockSpin(1);
+    }
+  while (cpu->debug_gnt_o == 0);
+
+  // Don't need to request once we get the grant.
+  cpu->debug_req_i = 0;
+
+  if (!write_enable)
+  {
+    // For reads, we need to read the data when we get rvalid_o.
+    // This could be on the same cycle as the grant, or later.
+    while (cpu->debug_rvalid_o == 0)
+    {
+      clockSpin(1);
+    }
+    val = cpu->debug_rdata_o;
+  }
+}
+
+// Read a debug register
+uint32_t debugRead(uint32_t addr)
+{
+  uint32_t val;
+  debugAccess(addr, val, false);
+  return val;
+}
+
+// Write a debug register
+void debugWrite(uint32_t addr, uint32_t val)
+{
+  debugAccess(addr, val, true);
+}
+
+// Cycle the clock until the debug unit reports that the CPU is halted.
+void waitForDebugStall()
+{
+  // Assume that stall could happen at any point - we don't need to wait a cycle
+  // to check if it's stalled before reading
+  while (!(debugRead(DBG_CTRL) & DBG_CTRL_HALT))
+  {
+    clockSpin(1);
+  }
+}
+
+// Single-step the CPU
+void stepSingle ()
+{
+  cout << "DBG_CTRL  " << std::hex << debugRead(DBG_CTRL) << std::dec << endl;
+  cout << "DBG_HIT   " << std::hex << debugRead(DBG_HIT) << std::dec << endl;
+  cout << "DBG_CAUSE " << std::hex << debugRead(DBG_CAUSE) << std::dec << endl;
+  cout << "DBG_NPC   " << std::hex << debugRead(DBG_NPC) << std::dec << endl;
+  cout << "DBG_PPC   " << std::hex << debugRead(DBG_PPC) << std::dec << endl;
+
+  cout << "About to do one single step" << endl;
+
+  // Clear DBG_HIT
+  debugWrite(DBG_HIT, 0);
+
+  // Write SSTE into the debug register
+  debugWrite(DBG_CTRL, DBG_CTRL_SSTE);
+
+  // Wait until the step is completed
+  waitForDebugStall();
+}
+
+// Write some program code into memory:
+//
+// ; Store a word to memory first:
+// li a5, 64
+// li a4, 102
+// sw a4, 0(a5)
+// ; Repeated <repeat_factor> times (20 at present)
+//
+// ; Then do something a bit like _exit(0)
+// li a1, 0
+// li a2, 0
+// li a3, 0
+// li a7, 93
+// ecall
+//
+// Execution begins at 0x80, so that's where we write our code.
+void loadProgram()
+{
+  uint32_t addr = 0x80;
+  uint32_t repeat_factor = 20;
+  for (size_t i = 0; i < repeat_factor; i++)
+  {
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x0, 0x93);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x1, 0x07);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x2, 0x00);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x3, 0x04);
+
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x4, 0x13);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x5, 0x07);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x6, 0x60);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x7, 0x06);
+
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x8, 0x23);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x9, 0xa0);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xa, 0xe7);
+    cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xb, 0x00);
+
+    addr += 0xC;
+  }
+
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x0, 0x93);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x1, 0x05);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x2, 0x00);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x3, 0x00);
+
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x4, 0x13);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x5, 0x06);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x6, 0x00);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x7, 0x00);
+
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x8, 0x93);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x9, 0x06);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xa, 0x00);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xb, 0x00);
+
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xc, 0x93);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xd, 0x08);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xe, 0xd0);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0xf, 0x05);
+
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x10, 0x73);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x11, 0x00);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x12, 0x00);
+  cpu->top->ram_i->dp_ram_i->writeByte (addr + 0x13, 0x00);
+}
+
+int
+main (int    argc,
+      char * argv[])
+{
+  // Instantiate the model
+  cpu = new Vtop;
+
+  // Open VCD
+  Verilated::traceEverOn (true);
+  tfp = new VerilatedVcdC;
+  cpu->trace (tfp, 99);
+  tfp->open ("model.vcd");
+
+  // Fix some signals for now.
+  cpu->irq_i          = 0;
+  cpu->debug_req_i    = 0;
+  cpu->fetch_enable_i = 0;
+
+  // Cycle through reset
+  cpu->rstn_i = 0;
+  clockSpin(5);
+  cpu->rstn_i = 1;
+
+  // Put a few instructions in memory
+  loadProgram();
+
+  cout << "About to halt and set traps on exceptions" << endl;
+
+  // Try to halt the CPU in the same way as in spi_debug_test.svh
+  debugWrite(DBG_CTRL, debugRead(DBG_CTRL) | DBG_CTRL_HALT);
+
+  // Let things run for a few cycles while the CPU waits in a halted state,
+  // simply to check that doing so doesn't cause any errors.
+  clockSpin(5);
+
+  // Set traps on exceptions
+  debugWrite(DBG_IE, 0xF);
+
+  cout << "About to resume" << endl;
+
+  uint32_t new_ctrl = debugRead(DBG_CTRL) & ~DBG_CTRL_HALT;
+  debugWrite(DBG_CTRL, new_ctrl);
+
+  cpu->fetch_enable_i = 1;
+
+  cout << "Cycling clock to run for a few instructions" << endl;
+  clockSpin(20);
+
+  cout << "Halting" << endl;
+
+  debugWrite(DBG_CTRL, debugRead(DBG_CTRL) | DBG_CTRL_HALT);
+  waitForDebugStall();
+
+  cout << "Halted. Setting single step" << endl;
+
+  debugWrite(DBG_CTRL, DBG_CTRL_HALT | DBG_CTRL_SSTE);
+
+  // Try and step 5 instructions
+  for (int j=0; j<5; j++) {
+    stepSingle ();
+  }
+
+  // Close VCD
+
+  tfp->close ();
+
+  // Tidy up
+
+  delete tfp;
+  delete cpu;
+
+}
+
+//! Function to handle $time calls in the Verilog
+
+double
+sc_time_stamp ()
+{
+  return cpuTime;
+
+}
+
+// Local Variables:
+// mode: C++
+// c-file-style: "gnu"
+// show-trailing-whitespace: t
+// End:

--- a/verilator-model/top.sv
+++ b/verilator-model/top.sv
@@ -1,0 +1,164 @@
+// Copyright 2017 Embecosm Limited <www.embecosm.com>
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Top level wrapper for RI5CY
+// Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+//
+// This instantiates memory and (eventually) a debug interface for the core.
+
+module top
+#(
+  parameter INSTR_RDATA_WIDTH = 128,
+  parameter ADDR_WIDTH = 22,
+  parameter BOOT_ADDR  = 'h80		// Consistent with Pulpino
+  )
+(
+ // Clock and Reset
+ input logic 			 clk_i,
+ input logic 			 rstn_i,
+
+ // Interrupt inputs
+ input logic 			 irq_i, // level sensitive IR lines
+ input logic [4:0] 		 irq_id_i,
+ output logic 			 irq_ack_o,
+ output logic [4:0] 		 irq_id_o,
+ input logic 			 irq_sec_i,
+
+ output logic 			 sec_lvl_o,
+
+ // Debug Interface
+ input logic 			 debug_req_i,
+ output logic 			 debug_gnt_o,
+ output logic 			 debug_rvalid_o,
+ input logic [14:0] 		 debug_addr_i,
+ input logic 			 debug_we_i,
+ input logic [31:0] 		 debug_wdata_i,
+ output logic [31:0] 		 debug_rdata_o,
+ output logic 			 debug_halted_o,
+
+ // CPU Control Signals
+ input logic 			 fetch_enable_i,
+ output logic 			 core_busy_o
+ );
+
+   // signals connecting core to memory
+
+   logic 	          instr_req;
+   logic 	          instr_gnt;
+   logic 	          instr_rvalid;
+   logic [ADDR_WIDTH-1:0] instr_addr;
+   logic [127:0] 	  instr_rdata;
+
+   logic 		  data_req;
+   logic 		  data_gnt;
+   logic 		  data_rvalid;
+   logic [ADDR_WIDTH-1:0] data_addr;
+   logic 		  data_we;
+   logic [3:0] 		  data_be;
+   logic [31:0] 	  data_rdata;
+   logic [31:0] 	  data_wdata;
+
+   // Instantiate the core
+
+   riscv_core
+     #(
+       .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH)
+       )
+   riscv_core_i
+     (
+      .clk_i                  ( clk_i                 ),
+      .rst_ni                 ( rstn_i                ),
+
+      .clock_en_i             ( '1                    ),
+      .test_en_i              ( '1                    ),
+
+      .boot_addr_i            ( BOOT_ADDR             ),
+      .core_id_i              ( 4'h0                  ),
+      .cluster_id_i           ( 6'h0                  ),
+
+      .instr_addr_o           ( instr_addr            ),
+      .instr_req_o            ( instr_req             ),
+      .instr_rdata_i          ( instr_rdata           ),
+      .instr_gnt_i            ( instr_gnt             ),
+      .instr_rvalid_i         ( instr_rvalid          ),
+
+      .data_addr_o            ( data_addr             ),
+      .data_wdata_o           ( data_wdata            ),
+      .data_we_o              ( data_we               ),
+      .data_req_o             ( data_req              ),
+      .data_be_o              ( data_be               ),
+      .data_rdata_i           ( data_rdata            ),
+      .data_gnt_i             ( data_gnt              ),
+      .data_rvalid_i          ( data_rvalid           ),
+      .data_err_i             ( 1'b0                  ),
+
+      .apu_master_req_o       (                       ),
+      .apu_master_ready_o     (                       ),
+      .apu_master_gnt_i       (                       ),
+      .apu_master_operands_o  (                       ),
+      .apu_master_op_o        (                       ),
+      .apu_master_type_o      (                       ),
+      .apu_master_flags_o     (                       ),
+      .apu_master_valid_i     (                       ),
+      .apu_master_result_i    (                       ),
+      .apu_master_flags_i     (                       ),
+
+      .irq_i                  ( irq_i                 ),
+      .irq_id_i               ( irq_id_i              ),
+      .irq_ack_o              ( irq_ack_o             ),
+      .irq_id_o               ( irq_id_o              ),
+      .irq_sec_i              ( irq_sec_i             ),
+
+      .sec_lvl_o              ( sec_lvl_o             ),
+
+      .debug_req_i            ( debug_req_i           ),
+      .debug_gnt_o            ( debug_gnt_o           ),
+      .debug_rvalid_o         ( debug_rvalid_o        ),
+      .debug_addr_i           ( debug_addr_i          ),
+      .debug_we_i             ( debug_we_i            ),
+      .debug_wdata_i          ( debug_wdata_i         ),
+      .debug_rdata_o          ( debug_rdata_o         ),
+      .debug_halted_o         ( debug_halted_o        ),
+      .debug_halt_i           ( 1'b0                  ),     // Not used in
+      .debug_resume_i         ( 1'b0                  ),     // single core
+
+      .fetch_enable_i         ( fetch_enable_i        ),
+      .core_busy_o            ( core_busy_o           ),
+
+      .ext_perf_counters_i    (                       )
+      );
+
+   // Instantiate the memory
+
+   ram
+     #(
+       .ADDR_WIDTH (ADDR_WIDTH - 2)
+       )
+   ram_i
+     (
+      .clk            ( clk_i        ),
+
+      .instr_req_i    ( instr_req    ),
+      .instr_addr_i   ( instr_addr   ),
+      .instr_rdata_o  ( instr_rdata  ),
+      .instr_rvalid_o ( instr_rvalid ),
+      .instr_gnt_o    ( instr_gnt    ),
+
+      .data_req_i     ( data_req     ),
+      .data_addr_i    ( data_addr    ),
+      .data_we_i      ( data_we      ),
+      .data_be_i      ( data_be      ),
+      .data_wdata_i   ( data_wdata   ),
+      .data_rdata_o   ( data_rdata   ),
+      .data_rvalid_o  ( data_rvalid  ),
+      .data_gnt_o     ( data_gnt     )
+      );
+
+endmodule	// top


### PR DESCRIPTION
Further to discussion with Davide Rossi at ORConf, this pull request adds a Verilator model that can be used for cycle-accurate modelling of the RI5CY core. A very simple RAM is also added (a modified version of one copied from Pulpino).

This is the same model that was presented along with performance and GCC regression test results at ORConf ( http://gmarkall.github.io/tutorials/orconf-2017/#1 ) and is used in the toolchain we have been working with ( https://github.com/embecosm/riscv-toolchain/tree/orconf#orconf-risc-v-toolchain-quick-start ).

A testbench for the model is included, which demonstrates how the model can be driven from C++, in particular:

- Instantiating the model
- Writing data to memory (a short program)
- Resetting the CPU
- Running the CPU
- Using the debug unit to halt, set traps on exceptions, single-step, and resume.

The testbench only provides a sample of running a very simple sequence of instructions - for running (and debugging) whole programs on the model through GDB, the [Toolchain Quick-start Guide ](https://github.com/embecosm/riscv-toolchain/tree/orconf#orconf-risc-v-toolchain-quick-start) explains the steps to follow.

Feedback is very welcome - this is our first PR to the project, so any guidance would be much appreciated!