### PR TITLE
Eliminate infinite loops in simulation

### DIFF
--- a/riscv_controller.sv
+++ b/riscv_controller.sv
@@ -224,7 +224,6 @@ module riscv_controller
 
     ctrl_busy_o            = 1'b1;
     first_fetch_o          = 1'b0;
-    is_decoding_o          = 1'b0;
 
     halt_if_o              = 1'b0;
     halt_id_o              = 1'b0;
@@ -249,6 +248,8 @@ module riscv_controller
       // We were just reset, wait for fetch_enable
       RESET:
       begin
+        is_decoding_o = 1'b0;
+
         ctrl_busy_o   = 1'b0;
         instr_req_o   = 1'b0;
 
@@ -264,6 +265,7 @@ module riscv_controller
       // copy boot address to instr fetch address
       BOOT_SET:
       begin
+        is_decoding_o = 1'b0;
         instr_req_o   = 1'b1;
         pc_mux_o      = PC_BOOT;
         pc_set_o      = 1'b1;
@@ -273,6 +275,7 @@ module riscv_controller
 
       WAIT_SLEEP:
       begin
+        is_decoding_o = 1'b0;
         ctrl_busy_o   = 1'b0;
         instr_req_o   = 1'b0;
         halt_if_o     = 1'b1;
@@ -285,6 +288,7 @@ module riscv_controller
       begin
         // we begin execution when either fetch_enable is high or an
         // interrupt has arrived
+        is_decoding_o = 1'b0;
         ctrl_busy_o   = 1'b0;
         instr_req_o   = 1'b0;
         halt_if_o     = 1'b1;
@@ -310,6 +314,7 @@ module riscv_controller
 
       FIRST_FETCH:
       begin
+        is_decoding_o = 1'b0;
         first_fetch_o = 1'b1;
         // Stall because of IF miss
         if ((id_ready_i == 1'b1) && (dbg_stall_i == 1'b0))
@@ -330,11 +335,12 @@ module riscv_controller
       DECODE:
       begin
 
-        is_decoding_o = 1'b0;
-
           if (branch_taken_ex_i)
           begin //taken branch
             // there is a branch in the EX stage that is taken
+            
+            is_decoding_o = 1'b0;
+
             pc_mux_o      = PC_BRANCH;
             pc_set_o      = 1'b1;
             dbg_trap_o    = dbg_settings_i[DBG_SETS_SSTE];
@@ -428,11 +434,15 @@ module riscv_controller
               end //decondig block
             endcase
           end  //valid block
+          else begin
+            is_decoding_o = 1'b0;
+          end
       end
 
       // a branch was in ID when a debug trap is hit
       DBG_WAIT_BRANCH:
       begin
+        is_decoding_o = 1'b0;
         halt_if_o = 1'b1;
 
         if (branch_taken_ex_i) begin
@@ -448,6 +458,8 @@ module riscv_controller
       // can examine our current state
       DBG_SIGNAL:
       begin
+        is_decoding_o = 1'b0;
+        
         dbg_ack_o   = 1'b1;
         halt_if_o   = 1'b1;
         ctrl_fsm_ns = DBG_WAIT;
@@ -455,6 +467,8 @@ module riscv_controller
 
       DBG_SIGNAL_SLEEP:
       begin
+        is_decoding_o = 1'b0;
+
         dbg_ack_o  = 1'b1;
         halt_if_o  = 1'b1;
 
@@ -463,6 +477,8 @@ module riscv_controller
 
       DBG_SIGNAL_ELW:
       begin
+        is_decoding_o = 1'b0;
+
         dbg_ack_o  = 1'b1;
         halt_if_o  = 1'b1;
 
@@ -471,6 +487,8 @@ module riscv_controller
 
       DBG_WAIT_ELW:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o = 1'b1;
 
         if (dbg_jump_req_i) begin
@@ -489,6 +507,8 @@ module riscv_controller
       // we wait until it is done and go back to SLEEP
       DBG_WAIT_SLEEP:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o = 1'b1;
 
         if (dbg_jump_req_i) begin
@@ -506,6 +526,8 @@ module riscv_controller
       // we wait until it is done and go back to DECODE
       DBG_WAIT:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o = 1'b1;
 
         if (dbg_jump_req_i) begin
@@ -523,6 +545,8 @@ module riscv_controller
       // flush the pipeline, insert NOP into EX stage
       FLUSH_EX:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o = 1'b1;
         halt_id_o = 1'b1;
         if (ex_valid_i)
@@ -532,6 +556,8 @@ module riscv_controller
 
       IRQ_FLUSH:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o   = 1'b1;
         halt_id_o   = 1'b1;
 
@@ -546,6 +572,8 @@ module riscv_controller
 
       ELW_EXE:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o   = 1'b1;
         halt_id_o   = 1'b1;
         //if we are here, a elw is executing now in the EX stage
@@ -565,6 +593,7 @@ module riscv_controller
 
       IRQ_TAKEN_ID:
       begin
+        is_decoding_o = 1'b0;
 
         pc_set_o          = 1'b1;
         pc_mux_o          = PC_EXCEPTION;
@@ -590,6 +619,8 @@ module riscv_controller
 
       IRQ_TAKEN_IF:
       begin
+        is_decoding_o = 1'b0;
+
         pc_set_o          = 1'b1;
         pc_mux_o          = PC_EXCEPTION;
         exc_pc_mux_o      = EXC_PC_IRQ;
@@ -616,6 +647,8 @@ module riscv_controller
       // flush the pipeline, insert NOP into EX and WB stage
       FLUSH_WB:
       begin
+        is_decoding_o = 1'b0;
+
         halt_if_o = 1'b1;
         halt_id_o = 1'b1;
 
@@ -686,6 +719,7 @@ module riscv_controller
       end
 
       default: begin
+        is_decoding_o = 1'b0;
         instr_req_o = 1'b0;
         ctrl_fsm_ns = RESET;
       end

--- a/riscv_prefetch_buffer.sv
+++ b/riscv_prefetch_buffer.sv
@@ -116,7 +116,6 @@ module riscv_prefetch_buffer
   begin
     hwlp_NS     = hwlp_CS;
     fifo_hwlp   = 1'b0;
-    hwlp_masked = 1'b0;
     fifo_clear  = 1'b0;
 
     unique case (hwlp_CS)
@@ -132,6 +131,9 @@ module riscv_prefetch_buffer
           if (ready_i)
             fifo_clear = 1'b1;
         end
+        else begin
+          hwlp_masked = 1'b0;
+        end
       end
 
       HWLP_IN: begin
@@ -146,6 +148,8 @@ module riscv_prefetch_buffer
 
       // just waiting for rvalid really
       HWLP_FETCHING: begin
+        hwlp_masked = 1'b0;
+
         fifo_hwlp = 1'b1;
 
         if (instr_rvalid_i & (CS != WAIT_ABORTED)) begin
@@ -160,11 +164,15 @@ module riscv_prefetch_buffer
       end
 
       HWLP_DONE: begin
+        hwlp_masked = 1'b0;
+
         if (valid_o & is_hwlp_o)
           hwlp_NS = HWLP_NONE;
       end
 
       default: begin
+        hwlp_masked = 1'b0;
+        
         hwlp_NS = HWLP_NONE;
       end
     endcase


### PR DESCRIPTION
During regular operation of the RI5CY core, the riscv_controller and
riscv_prefetch_buffer modules can lead the HDL simulator into an infinite
loop of two combinational processes causing each other to be evaluated
again and again: Under specific circumstances, each of the processes
assigns a variable that the other process is sensitive to first with zero
and then with one. At least one of these assignments causes the variable
to change, therefore causing another evaluation event for the other
process, which in turn does the same, just with a different variable.

The processes and corresponding variables that caused this behavior were:

In riscv_controller:
- The core controller process
  - is sensitive to changes of jr_stall_o
  - resets and then sets is_decoding_o
- The stall control process
  - is sensitive to changes of is_decoding_o
  - resets and then sets jr_stall_o

In riscv_prefetch_buffer:
- The fetch addr process
  - is sensitive to changes of fetch_is_hwlp
  - resets and then sets hwlp_masked
- The instruction fetch FSM process
  - is sensitive to changes of hwlp_masked
  - resets and then sets fetch_is_hwlp

This behavior was encountered with Vivado 2017.2 XSIM and seems to be in
accordance with the simulation reference algorithm outlined in the
SystemVerilog standard IEEE 1800-2012 in section 4.5 and the scheduling
implications of blocking assignments in section 4.9.3.

I got rid of this infinite loop behavior by removing the default zero
assignment of hwlp_masked / is_decoding_o at the beginning of the fetch addr /
core controller process and instead making explicit assignments in each of
the case branches. This way, if the value of the variables does not change,
the other process is not triggered again unintentionally.

No actual logic feedback circuit is described by the behavioral HDL in
either riscv_controller or riscv_prefetch_buffer, so this problem is only
relevant for behavioral simulation, not the post-synthesis circuit.