### PR TITLE
Fix ALU fmin/fmax to use float, not int comparison

### DIFF
--- a/riscv_alu.sv
+++ b/riscv_alu.sv
@@ -438,7 +438,7 @@ module riscv_alu
                     (operator_i == ALU_CLIP) || (operator_i == ALU_CLIPU) ||
                     (operator_i == ALU_FMIN);
 
-  assign sel_minmax[3:0]      = is_greater ^ {4{do_min}};
+  assign sel_minmax[3:0]      = ((operator_i == ALU_FMIN || operator_i == ALU_FMAX) ? f_is_greater : is_greater) ^ {4{do_min}};
 
   assign result_minmax[31:24] = (sel_minmax[3] == 1'b1) ? operand_a_i[31:24] : minmax_b[31:24];
   assign result_minmax[23:16] = (sel_minmax[2] == 1'b1) ? operand_a_i[23:16] : minmax_b[23:16];


### PR DESCRIPTION
The fmin.s / fmax.s instructions gave wrong results, because
they used the integer comparison flag, not the float comparison
flag.

A minimal example to demonstrate the unintended behavior of of fmax.s is attached. In this example fmax.s(-200, -190) gave -200 as a result. [fmax_min_example.c.txt](https://github.com/pulp-platform/riscv/files/1422550/fmax_min_example.c.txt)

I found this problem when a C program that uses floats returned wrong results when using the RI5CY core with FPU. The ri5cy toolchain gcc makes frequent use of the fmax.s when optimizing with -O3.
