### PR TITLE
Fix incomplete combinatorial (latch) for prefetch buffer

### DIFF
--- a/riscv_prefetch_buffer.sv
+++ b/riscv_prefetch_buffer.sv
@@ -123,6 +123,7 @@ module riscv_prefetch_buffer
     fifo_clear         = 1'b0;
     hwlp_branch        = 1'b0;
     hwloop_speculative = 1'b0;
+    hwlp_masked        = 1'b0;
 
     unique case (hwlp_CS)
       HWLP_NONE: begin


### PR DESCRIPTION
hwlp_masked is not defined in all paths of the combinatorial process, hence assign a default.