### PR TITLE
:art: Improve for loop format

### DIFF
--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -899,14 +899,15 @@ module riscv_id_stage
      assign apu_write_regs_valid_o   = apu_write_regs_valid;
   end
      else begin
-       for (genvar i=0;i<APU_NARGS_CPU;i++)
-        assign apu_operands[i]         = '0;
-        assign apu_waddr               = '0;
-        assign apu_flags               = '0;
-        assign apu_write_regs_o        = '0;
-        assign apu_read_regs_o         = '0;
-        assign apu_write_regs_valid_o  = '0;
-        assign apu_read_regs_valid_o   = '0;
+       for (genvar i=0; i<APU_NARGS_CPU; i++) begin : apu_tie_off
+         assign apu_operands[i]       = '0;
+       end
+       assign apu_waddr               = '0;
+       assign apu_flags               = '0;
+       assign apu_write_regs_o        = '0;
+       assign apu_read_regs_o         = '0;
+       assign apu_write_regs_valid_o  = '0;
+       assign apu_read_regs_valid_o   = '0;
      end
   endgenerate
 


### PR DESCRIPTION
Add begin/end keywords to for statement in apu signal tieoff to explicitly denote that only the next line of code is going through a generate loop.
Fixes #33