### PR TITLE
Fix Verilator model build

### DIFF
--- a/verilator-model/Makefile
+++ b/verilator-model/Makefile
@@ -45,6 +45,7 @@ VSRC = cluster_clock_gating.sv            \
        ../rtl/include/apu_core_package.sv     \
        ../rtl/include/riscv_defines.sv        \
        ../rtl/include/riscv_tracer_defines.sv \
+       ../rtl/register_file_test_wrap.sv      \
        ../rtl/riscv_alu.sv                    \
        ../rtl/riscv_alu_basic.sv              \
        ../rtl/riscv_alu_div.sv                \


### PR DESCRIPTION
The most recent commit add a new file - `../rtl/register_file_test_wrap.sv` - which needs to be Verilated too.

This fixes the build - the testbench produces the expected output once this fix is applied.