### PR TITLE
Fix verilator model

### DIFF
--- a/verilator-model/Makefile
+++ b/verilator-model/Makefile
@@ -20,7 +20,7 @@
 VERILATOR = verilator
 VDIR = obj_dir
 CPPFLAGS = -I$(VDIR) `pkg-config --cflags verilator`
-CXXFLAGS = -Wall -Werror -std=c++11
+CXXFLAGS = -Wall -Werror -std=c++11 -Wno-aligned-new
 CXX = g++
 LD = g++
 
@@ -67,7 +67,8 @@ VSRC = cluster_clock_gating.sv            \
        ../rtl/riscv_register_file.sv          \
        ../rtl/riscv_core.sv                   \
        ../rtl/riscv_apu_disp.sv               \
-       ../rtl/riscv_L0_buffer.sv
+       ../rtl/riscv_L0_buffer.sv              \
+       ../rtl/riscv_pmp.sv
 
 VINC = ../rtl/include
 

--- a/verilator-model/top.sv
+++ b/verilator-model/top.sv
@@ -69,7 +69,8 @@ module top
 
    riscv_core
      #(
-       .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH)
+       .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
+       .PULP_SECURE (0)
        )
    riscv_core_i
      (
@@ -78,6 +79,7 @@ module top
 
       .clock_en_i             ( '1                    ),
       .test_en_i              ( '1                    ),
+      .fregfile_disable_i     ( '0                    ),
 
       .boot_addr_i            ( BOOT_ADDR             ),
       .core_id_i              ( 4'h0                  ),
@@ -97,7 +99,6 @@ module top
       .data_rdata_i           ( data_rdata            ),
       .data_gnt_i             ( data_gnt              ),
       .data_rvalid_i          ( data_rvalid           ),
-      .data_err_i             ( 1'b0                  ),
 
       .apu_master_req_o       (                       ),
       .apu_master_ready_o     (                       ),


### PR DESCRIPTION
With the latest changes there were a few regression in the verilator testbench. Here are fixes related to verilator and newer gcc versions.

`verilator-model/Makefile`:
Need to ignore aligned-new warnings to make compilation work on newer gcc
without breaking older versions.
Add `riscv_pmp` to be verilated too.

`verilator-model/top.sv`:
Disable PULP_SECURE since in `riscv_cs_registers` there is a blocking and
non-blocking assignment to `pmp_req_q` which verilator can't deal with.
Remove `data_err_i` (doesn't exist anymore).
Add `fregfile_disable_i`.