### PR TITLE
Add workaround for mailbox

### DIFF
--- a/tb/tb_riscv/riscv_random_stall.sv
+++ b/tb/tb_riscv/riscv_random_stall.sv
@@ -85,10 +85,10 @@ class rand_data_cycles;
      rand int n;
 endclass : rand_data_cycles
 
-mailbox core_reqs          = new (4);
-mailbox core_resps         = new (4);
+mailbox #(stall_mem_t) core_reqs          = new (4);
+mailbox #(stall_mem_t) core_resps         = new (4);
 mailbox core_resps_granted = new (4);
-mailbox memory_transfers   = new (4);
+mailbox #(stall_mem_t) memory_transfers   = new (4);
 
  always_latch
  begin

--- a/tb/tb_riscv/riscv_simchecker.sv
+++ b/tb/tb_riscv/riscv_simchecker.sv
@@ -256,6 +256,7 @@ module riscv_simchecker
       instr_trace_t trace, fpu_trace;
       reg_t         reg_write;
       logic [31:0]  tmp_discard;
+      logic [31:0]  rdata_tmp;
 
       while(1) begin
         instr_wb.get(trace);
@@ -312,7 +313,9 @@ module riscv_simchecker
               if (rdata_writes > 0)
                 $warning("rdata_writes is > 0, but we are waiting for a read");
 
-              rdata_stack.get(trace.mem_access[i].rdata);
+              // indirect addressing workaround for ncsim
+              rdata_tmp = trace.mem_access[i].rdata;
+              rdata_stack.get(rdata_tmp);
             end
           end
         end


### PR DESCRIPTION
Xcelium errors out with MBXERR when trying to compile generic mailboxes.