### PR TITLE
Fix tb/core when INSTR_RDATA_WIDTH = 32

### DIFF
--- a/tb/core/dp_ram.sv
+++ b/tb/core/dp_ram.sv
@@ -10,47 +10,37 @@
 // specific language governing permissions and limitations under the License.
 
 module dp_ram
-    #(parameter ADDR_WIDTH = 8)
+    #(parameter ADDR_WIDTH = 8,
+      parameter INSTR_RDATA_WIDTH = 128)
     (input logic                  clk_i,
 
-     input logic                  en_a_i,
-     input logic [ADDR_WIDTH-1:0] addr_a_i,
-     input logic [31:0]           wdata_a_i,
-     output logic [127:0]         rdata_a_o,
-     input logic                  we_a_i,
-     input logic [3:0]            be_a_i,
+     input logic                          en_a_i,
+     input logic [ADDR_WIDTH-1:0]         addr_a_i,
+     input logic [31:0]                   wdata_a_i,
+     output logic [INSTR_RDATA_WIDTH-1:0] rdata_a_o,
+     input logic                          we_a_i,
+     input logic [3:0]                    be_a_i,
 
-     input logic                  en_b_i,
-     input logic [ADDR_WIDTH-1:0] addr_b_i,
-     input logic [31:0]           wdata_b_i,
-     output logic [31:0]          rdata_b_o,
-     input logic                  we_b_i,
-     input logic [3:0]            be_b_i);
+     input logic                          en_b_i,
+     input logic [ADDR_WIDTH-1:0]         addr_b_i,
+     input logic [31:0]                   wdata_b_i,
+     output logic [31:0]                  rdata_b_o,
+     input logic                          we_b_i,
+     input logic [3:0]                    be_b_i);
 
     localparam bytes = 2**ADDR_WIDTH;
 
     logic [7:0]                      mem[bytes];
+    logic [ADDR_WIDTH-1:0]           addr_a_int;
     logic [ADDR_WIDTH-1:0]           addr_b_int;
 
+    always_comb addr_a_int = {addr_a_i[ADDR_WIDTH-1:2], 2'b0};
     always_comb addr_b_int = {addr_b_i[ADDR_WIDTH-1:2], 2'b0};
 
     always @(posedge clk_i) begin
-        rdata_a_o[  0+: 8] <= mem[addr_a_i +  0];
-        rdata_a_o[  8+: 8] <= mem[addr_a_i +  1];
-        rdata_a_o[ 16+: 8] <= mem[addr_a_i +  2];
-        rdata_a_o[ 24+: 8] <= mem[addr_a_i +  3];
-        rdata_a_o[ 32+: 8] <= mem[addr_a_i +  4];
-        rdata_a_o[ 40+: 8] <= mem[addr_a_i +  5];
-        rdata_a_o[ 48+: 8] <= mem[addr_a_i +  6];
-        rdata_a_o[ 56+: 8] <= mem[addr_a_i +  7];
-        rdata_a_o[ 64+: 8] <= mem[addr_a_i +  8];
-        rdata_a_o[ 72+: 8] <= mem[addr_a_i +  9];
-        rdata_a_o[ 80+: 8] <= mem[addr_a_i + 10];
-        rdata_a_o[ 88+: 8] <= mem[addr_a_i + 11];
-        rdata_a_o[ 96+: 8] <= mem[addr_a_i + 12];
-        rdata_a_o[104+: 8] <= mem[addr_a_i + 13];
-        rdata_a_o[112+: 8] <= mem[addr_a_i + 14];
-        rdata_a_o[120+: 8] <= mem[addr_a_i + 15];
+        for (int i = 0; i < INSTR_RDATA_WIDTH/8; i++) begin
+            rdata_a_o[(i*8)+: 8] <= mem[addr_a_int +  i];
+        end
 
         /* addr_b_i is the actual memory address referenced */
         if (en_b_i) begin

--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -16,34 +16,35 @@
 // processor core and some pseudo peripherals
 
 module mm_ram
-    #(parameter RAM_ADDR_WIDTH = 16)
-    (input logic                      clk_i,
-     input logic                      rst_ni,
+    #(parameter RAM_ADDR_WIDTH = 16,
+      parameter INSTR_RDATA_WIDTH = 128)
+    (input logic                          clk_i,
+     input logic                          rst_ni,
 
-     input logic                      instr_req_i,
-     input logic [RAM_ADDR_WIDTH-1:0] instr_addr_i,
-     output logic [127:0]             instr_rdata_o,
-     output logic                     instr_rvalid_o,
-     output logic                     instr_gnt_o,
+     input logic                          instr_req_i,
+     input logic [RAM_ADDR_WIDTH-1:0]     instr_addr_i,
+     output logic [INSTR_RDATA_WIDTH-1:0] instr_rdata_o,
+     output logic                         instr_rvalid_o,
+     output logic                         instr_gnt_o,
 
-     input logic                      data_req_i,
-     input logic [31:0]               data_addr_i,
-     input logic                      data_we_i,
-     input logic [3:0]                data_be_i,
-     input logic [31:0]               data_wdata_i,
-     output logic [31:0]              data_rdata_o,
-     output logic                     data_rvalid_o,
-     output logic                     data_gnt_o,
+     input logic                          data_req_i,
+     input logic [31:0]                   data_addr_i,
+     input logic                          data_we_i,
+     input logic [3:0]                    data_be_i,
+     input logic [31:0]                   data_wdata_i,
+     output logic [31:0]                  data_rdata_o,
+     output logic                         data_rvalid_o,
+     output logic                         data_gnt_o,
 
-     input logic [4:0]                irq_id_i,
-     input logic                      irq_ack_i,
-     output logic [4:0]               irq_id_o,
-     output logic                     irq_o,
+     input logic [4:0]                    irq_id_i,
+     input logic                          irq_ack_i,
+     output logic [4:0]                   irq_id_o,
+     output logic                         irq_o,
 
-     output logic                     tests_passed_o,
-     output logic                     tests_failed_o,
-     output logic                     exit_valid_o,
-     output logic [31:0]              exit_value_o);
+     output logic                         tests_passed_o,
+     output logic                         tests_failed_o,
+     output logic                         exit_valid_o,
+     output logic [31:0]                  exit_value_o);
 
     localparam int                    TIMER_IRQ_ID = 3;
 
@@ -237,7 +238,8 @@ module mm_ram
 
     // instantiate the ram
     dp_ram
-        #(.ADDR_WIDTH (RAM_ADDR_WIDTH))
+        #(.ADDR_WIDTH (RAM_ADDR_WIDTH),
+          .INSTR_RDATA_WIDTH(INSTR_RDATA_WIDTH))
     dp_ram_i
         (
          .clk_i     ( clk_i         ),

--- a/tb/core/riscv_wrapper.sv
+++ b/tb/core/riscv_wrapper.sv
@@ -26,30 +26,30 @@ module riscv_wrapper
      output logic        exit_valid_o);
 
     // signals connecting core to memory
-    logic                        instr_req;
-    logic                        instr_gnt;
-    logic                        instr_rvalid;
-    logic [31:0]                 instr_addr;
-    logic [127:0]                instr_rdata;
+    logic                         instr_req;
+    logic                         instr_gnt;
+    logic                         instr_rvalid;
+    logic [31:0]                  instr_addr;
+    logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
 
-    logic                        data_req;
-    logic                        data_gnt;
-    logic                        data_rvalid;
-    logic [31:0]                 data_addr;
-    logic                        data_we;
-    logic [3:0]                  data_be;
-    logic [31:0]                 data_rdata;
-    logic [31:0]                 data_wdata;
+    logic                         data_req;
+    logic                         data_gnt;
+    logic                         data_rvalid;
+    logic [31:0]                  data_addr;
+    logic                         data_we;
+    logic [3:0]                   data_be;
+    logic [31:0]                  data_rdata;
+    logic [31:0]                  data_wdata;
 
     // signals to debug unit
-    logic                        debug_req_i;
+    logic                         debug_req_i;
 
     // irq signals (not used)
-    logic                        irq;
-    logic [0:4]                  irq_id_in;
-    logic                        irq_ack;
-    logic [0:4]                  irq_id_out;
-    logic                        irq_sec;
+    logic                         irq;
+    logic [0:4]                   irq_id_in;
+    logic                         irq_ack;
+    logic [0:4]                   irq_id_out;
+    logic                         irq_sec;
 
 
     // interrupts (only timer for now)
@@ -116,7 +116,8 @@ module riscv_wrapper
 
     // this handles read to RAM and memory mapped pseudo peripherals
     mm_ram
-        #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH))
+        #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
+          .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH))
     ram_i
         (.clk_i          ( clk_i                          ),
          .rst_ni         ( rst_ni                         ),

--- a/tb/core/tb_top.sv
+++ b/tb/core/tb_top.sv
@@ -136,4 +136,11 @@ module tb_top
          .exit_valid_o   ( exit_valid   ),
          .exit_value_o   ( exit_value   ));
 
+`ifndef VERILATOR
+    initial begin
+        assert (INSTR_RDATA_WIDTH == 128 || INSTR_RDATA_WIDTH == 32)
+            else $fatal("invalid INSTR_RDATA_WIDTH, choose 32 or 128");
+    end
+`endif
+
 endmodule // tb_top


### PR DESCRIPTION
We need the mm_ram to be only word addressable. Also assert that we use
valid values for INSTR_RDATA_WIDTH.