### PR TITLE
Add `fpnew` as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tb/core/fpnew"]
+	path = tb/core/fpnew
+	url = https://github.com/pulp-platform/fpnew

--- a/tb/core/Makefile
+++ b/tb/core/Makefile
@@ -168,10 +168,6 @@ verilate-clean:
 	if [ -d $(VERI_DIR) ]; then rm -r $(VERI_DIR); fi
 	rm -rf testbench_verilator
 
-# fpnew dependencies
-fpnew/src/fpnew_pkg.sv:
-	git clone git@github.com:pulp-platform/fpnew.git --recurse
-
 # run tb and exit
 .PHONY: vsim-run
 vsim-run: ALL_VSIM_FLAGS += -c


### PR DESCRIPTION
Hey folks, thanks for all the work on this. 

We currently do some systemc work that requires a riscv model which this repo provides nicely. In trying to automate some of our build-flow we ran across this somewhat icky `git clone` being done from a Makefile inside a source directory. 

I took the liberty to clean this up somewhat in our fork - please review if you wish, and do with this PR as you see fit :)