### PR TITLE
Support verilator for riscv-compliance and custom programs

### DIFF
--- a/tb/core/Makefile
+++ b/tb/core/Makefile
@@ -228,6 +228,11 @@ custom-vsim-run: vsim-all custom/hello_world.hex
 custom-vsim-run: ALL_VSIM_FLAGS += "+firmware=custom/hello_world.hex"
 custom-vsim-run: vsim-run
 
+.PHONY: custom-veri-run
+custom-veri-run: verilate custom/hello_world.hex
+	./testbench_verilator $(VERI_FLAGS) \
+		"+firmware=custom/hello_world.hex"
+
 # compile and dump picorv firmware
 firmware/firmware.elf: $(FIRMWARE_OBJS) $(FIRMWARE_TEST_OBJS) $(COMPLIANCE_TEST_OBJS) \
 				firmware/link.ld

--- a/tb/core/README.md
+++ b/tb/core/README.md
@@ -28,6 +28,10 @@ Toolchain](https://github.com/riscv/riscv-gnu-toolchain) for that (follow the
 `Installation (Newlib)` section) and point your `RISCV` environment variable to
 it.
 
+We have prepared a hello world program which you can run in the testbench. It
+demonstrates how you can run your own programs. Call `custom-vsim-run` or
+`custom-veri-run` to run it with `vsim` or `verilator` respectively.
+
 Running the testbench with vsim
 ----------------------
 Point you environment variable `RISCV` to your RISC-V toolchain. Call `make

--- a/tb/core/tb_top_verilator.sv
+++ b/tb/core/tb_top_verilator.sv
@@ -21,6 +21,14 @@ module tb_top_verilator
      output logic tests_passed_o,
      output logic tests_failed_o);
 
+    // cycle counter
+    int unsigned            cycle_cnt_q;
+
+    // testbench result
+    logic                   exit_valid;
+    logic [31:0]            exit_value;
+
+
     // we either load the provided firmware or execute a small test program that
     // doesn't do more than an infinite loop with some I/O
     initial begin: load_prog
@@ -39,6 +47,24 @@ module tb_top_verilator
         end
      end
 
+    // abort after n cycles, if we want to
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+        automatic int maxcycles;
+        if($value$plusargs("maxcycles=%d", maxcycles)) begin
+            if (~rst_ni) begin
+                cycle_cnt_q <= 0;
+            end else begin
+                cycle_cnt_q     <= cycle_cnt_q + 1;
+                if (cycle_cnt_q >= maxcycles) begin
+                    // we $finish instead of $fatal because riscv-compliance
+                    // interprets the return error code as total failure, which
+                    // we don't want
+                    $finish("Simulation aborted due to maximum cycle limit");
+                end
+            end
+        end
+    end
+
     // check if we succeded
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (tests_passed_o) begin
@@ -49,6 +75,13 @@ module tb_top_verilator
             $display("TEST(S) FAILED!");
             $finish;
         end
+        if (exit_valid) begin
+            if (exit_value == 0)
+                $display("EXIT SUCCESS");
+            else
+                $display("EXIT FAILURE: %d", exit_value);
+            $finish;
+        end
     end
 
     // wrapper for riscv, the memory system and stdout peripheral
@@ -56,14 +89,16 @@ module tb_top_verilator
         #(.INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
           .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
           .BOOT_ADDR (BOOT_ADDR),
-          .PULP_SECURE (1)) // need to disable because non-blocking and blocking
-                            // assignment to same variable
+          .PULP_SECURE (1)) // need to enable -Wno-BLKANDNBLK to silence warnin
+                            // about assignment from blk to non-blk
+
     riscv_wrapper_i
         (.clk_i          ( clk_i          ),
          .rst_ni         ( rst_ni         ),
          .fetch_enable_i ( fetch_enable_i ),
          .tests_passed_o ( tests_passed_o ),
-         .tests_failed_o ( tests_failed_o ));
+         .tests_failed_o ( tests_failed_o ),
+         .exit_valid_o   ( exit_valid     ),
+         .exit_value_o   ( exit_value     ));
 
 endmodule // tb_top_verilator
-


### PR DESCRIPTION
* Able to run custom programs with verilator now
* Add facilities that allow running riscv-compliance (upstream) with
  verilator by simply pointing `TARGET_SIM` to the compiled verilator
  testbench