### PR TITLE
:bug: Fixed ELW replay mechanism.

### DIFF
--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -189,7 +189,7 @@ module riscv_controller
   // FSM state encoding
   enum  logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
                       DECODE,
-                      IRQ_TAKEN_ID, IRQ_TAKEN_IF, IRQ_FLUSH, ELW_EXE,
+                      IRQ_TAKEN_ID, IRQ_TAKEN_IF, IRQ_FLUSH, IRQ_FLUSH_ELW, ELW_EXE,
                       FLUSH_EX, FLUSH_WB, XRET_JUMP,
                       DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH } ctrl_fsm_cs, ctrl_fsm_ns;
 
@@ -628,8 +628,6 @@ module riscv_controller
         halt_if_o   = 1'b1;
         halt_id_o   = 1'b1;
 
-        perf_pipeline_stall_o = data_load_event_i;
-
         if (data_err_i)
         begin //data error
             // the current LW or SW have been blocked by the PMP
@@ -646,13 +644,30 @@ module riscv_controller
             ctrl_fsm_ns = IRQ_TAKEN_ID;
           end else begin
             // we can go back to decode in case the IRQ is not taken (no ELW REPLAY)
-            exc_kill_o   = 1'b1;
-            instr_valid_irq_flush_n =1'b1;
-            ctrl_fsm_ns  = DECODE;
+            exc_kill_o              = 1'b1;
+            instr_valid_irq_flush_n = 1'b1;
+            ctrl_fsm_ns             = DECODE;
           end
         end
       end
 
+      IRQ_FLUSH_ELW:
+      begin
+        is_decoding_o = 1'b0;
+
+        halt_if_o   = 1'b1;
+        halt_id_o   = 1'b1;
+
+        perf_pipeline_stall_o = data_load_event_i;
+
+        if(irq_i & irq_enable_int) begin
+            ctrl_fsm_ns = IRQ_TAKEN_ID;
+        end else begin
+          // we can go back to decode in case the IRQ is not taken (no ELW REPLAY)
+          exc_kill_o              = 1'b1;
+          ctrl_fsm_ns             = DECODE;
+        end
+      end
 
       ELW_EXE:
       begin
@@ -668,8 +683,8 @@ module riscv_controller
         //If an interrupt occurs, we replay the ELW
         //No needs to check irq_int_req_i since in the EX stage there is only the elw, no CSR pendings
         if(id_ready_i)
-          ctrl_fsm_ns = (debug_req_i & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH;
-          // if from the ELW EXE we go to IRQ_FLUSH, it is assumed that if there was an IRQ req together with the grant and IE was valid, then
+          ctrl_fsm_ns = (debug_req_i & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH_ELW;
+          // if from the ELW EXE we go to IRQ_FLUSH_ELW, it is assumed that if there was an IRQ req together with the grant and IE was valid, then
           // there must be no hazard due to xIE
         else
           ctrl_fsm_ns = ELW_EXE;


### PR DESCRIPTION
To fix issue #160, the IRQ_FLUSH state when reached by the DECODE stage, was making the instruction valid for the next cycle.
This state was reachable also by the ELW_EXE, that was using it to proceed with the next instruction once the event has completed (clock enabled).
The DECODE state was considering the instruction valid due to #160, and so was reexecuting the ELW rather than the next instruction.
Now a new state reachable only by the ELW_EXE state has been added to differentiate the meaning of the 2 situations.