### PR TITLE
A Extension: Decode ops and send them to memory as `data_atop_o`

### DIFF
--- a/rtl/include/riscv_defines.sv
+++ b/rtl/include/riscv_defines.sv
@@ -52,6 +52,7 @@ parameter OPCODE_OP_FMSUB  = 7'h47;
 parameter OPCODE_OP_FNMSUB = 7'h4b;
 parameter OPCODE_STORE_FP  = 7'h27;
 parameter OPCODE_LOAD_FP   = 7'h07;
+parameter OPCODE_AMO       = 7'h2F;
 
 // those opcodes are now used for PULP custom instructions
 // parameter OPCODE_CUST0     = 7'h0b

--- a/rtl/include/riscv_defines.sv
+++ b/rtl/include/riscv_defines.sv
@@ -302,6 +302,18 @@ parameter JT_JAL  = 2'b01;
 parameter JT_JALR = 2'b10;
 parameter JT_COND = 2'b11;
 
+// Atomic operations
+parameter AMO_LR   = 5'b00010;
+parameter AMO_SC   = 5'b00011;
+parameter AMO_SWAP = 5'b00001;
+parameter AMO_ADD  = 5'b00000;
+parameter AMO_XOR  = 5'b00100;
+parameter AMO_AND  = 5'b01100;
+parameter AMO_OR   = 5'b01000;
+parameter AMO_MIN  = 5'b10000;
+parameter AMO_MAX  = 5'b10100;
+parameter AMO_MINU = 5'b11000;
+parameter AMO_MAXU = 5'b11100;
 
 ///////////////////////////////////////////////
 //   ___ _____   ____  _                     //

--- a/rtl/include/riscv_tracer_defines.sv
+++ b/rtl/include/riscv_tracer_defines.sv
@@ -184,7 +184,20 @@ parameter INSTR_FCLASS   =  { 5'b11100, 2'b00, 5'b0, 5'b?, 3'b001, 5'b?, OPCODE_
 parameter INSTR_FCVTSW   =  { 5'b11010, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, OPCODE_OP_FP };
 parameter INSTR_FCVTSWU  =  { 5'b11010, 2'b00, 5'b1, 5'b?, 3'b?, 5'b?, OPCODE_OP_FP };
 parameter INSTR_FMVSX    =  { 5'b11110, 2'b00, 5'b0, 5'b?, 3'b000, 5'b?, OPCODE_OP_FP };
-// to be used in tracer!
 
+// RV32A
+parameter INSTR_LR       =  { AMO_LR  , 2'b?, 5'b0, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_SC       =  { AMO_SC  , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOSWAP  =  { AMO_SWAP, 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOADD   =  { AMO_ADD , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOXOR   =  { AMO_XOR , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOAND   =  { AMO_AND , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOOR    =  { AMO_OR  , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOMIN   =  { AMO_MIN , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOMAX   =  { AMO_MAX , 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOMINU  =  { AMO_MINU, 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+parameter INSTR_AMOMAXU  =  { AMO_MAXU, 2'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_AMO };
+
+// to be used in tracer!
 
 endpackage

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -259,7 +259,7 @@ module riscv_core
 
   // Data Memory Control:  From ID stage (id-ex pipe) <--> load store unit
   logic        data_we_ex;
-  logic        data_atop_ex;
+  logic [5:0]  data_atop_ex;
   logic [1:0]  data_type_ex;
   logic [1:0]  data_sign_ext_ex;
   logic [1:0]  data_reg_offset_ex;

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -710,7 +710,7 @@ module riscv_core
     .data_err_i                   ( data_err_pmp         ),
     .data_err_ack_o               ( data_err_ack         ),
 
-    .atomic_op_ex_o               ( data_atomic_op_o     ),
+    .atomic_op_ex_o               ( data_atomic_op       ),
 
     // Interrupt Signals
     .irq_i                        ( irq_i                ), // incoming interrupts
@@ -911,6 +911,9 @@ module riscv_core
     .data_be_o             ( data_be_o          ),
     .data_wdata_o          ( data_wdata_o       ),
     .data_rdata_i          ( data_rdata_i       ),
+
+    .data_atomic_op_o      ( data_atomic_op_o   ),
+    .data_atomic_op_i      ( data_atomic_op     ),
 
     // signal from ex stage
     .data_we_ex_i          ( data_we_ex         ),

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -90,7 +90,7 @@ module riscv_core
   output logic [31:0] data_wdata_o,
   input  logic [31:0] data_rdata_i,
 
-  output logic [5:0]  data_atomic_op_o,
+  output logic [5:0]  data_atop_o,
 
   // apu-interconnect
   // handshake signals
@@ -259,6 +259,7 @@ module riscv_core
 
   // Data Memory Control:  From ID stage (id-ex pipe) <--> load store unit
   logic        data_we_ex;
+  logic        data_atop_ex;
   logic [1:0]  data_type_ex;
   logic [1:0]  data_sign_ext_ex;
   logic [1:0]  data_reg_offset_ex;
@@ -698,6 +699,7 @@ module riscv_core
     // LSU
     .data_req_ex_o                ( data_req_ex          ), // to load store unit
     .data_we_ex_o                 ( data_we_ex           ), // to load store unit
+    .atop_ex_o                    ( data_atop_ex         ),
     .data_type_ex_o               ( data_type_ex         ), // to load store unit
     .data_sign_ext_ex_o           ( data_sign_ext_ex     ), // to load store unit
     .data_reg_offset_ex_o         ( data_reg_offset_ex   ), // to load store unit
@@ -710,7 +712,6 @@ module riscv_core
     .data_err_i                   ( data_err_pmp         ),
     .data_err_ack_o               ( data_err_ack         ),
 
-    .atomic_op_ex_o               ( data_atomic_op       ),
 
     // Interrupt Signals
     .irq_i                        ( irq_i                ), // incoming interrupts
@@ -908,15 +909,14 @@ module riscv_core
 
     .data_addr_o           ( data_addr_pmp      ),
     .data_we_o             ( data_we_o          ),
+    .data_atop_o           ( data_atop_o        ),
     .data_be_o             ( data_be_o          ),
     .data_wdata_o          ( data_wdata_o       ),
     .data_rdata_i          ( data_rdata_i       ),
 
-    .data_atomic_op_o      ( data_atomic_op_o   ),
-    .data_atomic_op_i      ( data_atomic_op     ),
-
     // signal from ex stage
     .data_we_ex_i          ( data_we_ex         ),
+    .data_atop_ex_i        ( data_atop_ex       ),
     .data_type_ex_i        ( data_type_ex       ),
     .data_wdata_ex_i       ( alu_operand_c_ex   ),
     .data_reg_offset_ex_i  ( data_reg_offset_ex ),

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -90,6 +90,8 @@ module riscv_core
   output logic [31:0] data_wdata_o,
   input  logic [31:0] data_rdata_i,
 
+  output logic [5:0]  data_atomic_op_o,
+
   // apu-interconnect
   // handshake signals
   output logic                           apu_master_req_o,
@@ -707,6 +709,9 @@ module riscv_core
     .data_misaligned_i            ( data_misaligned      ),
     .data_err_i                   ( data_err_pmp         ),
     .data_err_ack_o               ( data_err_ack         ),
+
+    .atomic_op_ex_o               ( data_atomic_op_o     ),
+
     // Interrupt Signals
     .irq_i                        ( irq_i                ), // incoming interrupts
     .irq_sec_i                    ( (PULP_SECURE) ? irq_sec_i : 1'b0 ),

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -43,6 +43,7 @@ module riscv_core
   parameter N_PMP_ENTRIES       = 16,
   parameter USE_PMP             =  1, //if PULP_SECURE is 1, you can still not use the PMP
   parameter PULP_CLUSTER        =  1,
+  parameter A_EXTENSION         =  0,
   parameter FPU                 =  0,
   parameter Zfinx               =  0,
   parameter FP_DIVSQRT          =  0,
@@ -90,7 +91,7 @@ module riscv_core
   output logic [31:0] data_wdata_o,
   input  logic [31:0] data_rdata_i,
 
-  output logic [5:0]  data_atop_o,
+  output logic [5:0]  data_atop_o, // atomic operation, only active if parameter `A_EXTENSION != 0`
 
   // apu-interconnect
   // handshake signals
@@ -543,6 +544,7 @@ module riscv_core
   #(
     .N_HWLP                       ( N_HWLP               ),
     .PULP_SECURE                  ( PULP_SECURE          ),
+    .A_EXTENSION                  ( A_EXTENSION          ),
     .APU                          ( APU                  ),
     .FPU                          ( FPU                  ),
     .Zfinx                        ( Zfinx                ),

--- a/rtl/riscv_decoder.sv
+++ b/rtl/riscv_decoder.sv
@@ -144,7 +144,7 @@ module riscv_decoder
   output logic        data_load_event_o,       // data request is in the special event range
 
   // Atomic memory access
-  output  logic [5:0] atomic_op_o,
+  output  logic [5:0] atop_o,
 
   // hwloop signals
   output logic [2:0]  hwloop_we_o,             // write enable for hwloop regs
@@ -277,7 +277,7 @@ module riscv_decoder
     data_req                    = 1'b0;
     data_load_event_o           = 1'b0;
 
-    atomic_op_o                 = 5'b00000;
+    atop_o                      = 5'b00000;
 
     illegal_insn_o              = 1'b0;
     ebrk_insn_o                 = 1'b0;
@@ -509,11 +509,11 @@ module riscv_decoder
         unique case (instr_rdata_i[31:27])
           5'b00010: begin
             data_we_o = 1'b0; // LR
-            atomic_op_o = 6'h05;  // TODO: assign right value
+            atop_o    = AMO_LR;
           end
           5'b00011: begin // SC
             data_we_o = 1'b1;
-            atomic_op_o = 6'h0E; // TODO: assign right value
+            atop_o    = AMO_SC;
             alu_op_c_mux_sel_o = OP_C_REGB_OR_FWD;  // pass write data through ALU operand c
           end
           default : illegal_insn_o = 1'b1;

--- a/rtl/riscv_decoder.sv
+++ b/rtl/riscv_decoder.sv
@@ -495,19 +495,16 @@ module riscv_decoder
       OPCODE_AMO: begin
         if (instr_rdata_i[14:12] == 3'b010) begin // RV32A Extension (word)
           data_req          = 1'b1;
-          // alu_en_o          = 1'b0;
           data_type_o       = 2'b00;
           rega_used_o       = 1'b1;
           regb_used_o       = 1'b1;
-          // regc_used_o       = 1'b1;
-          // regc_mux_o        = REGC_RD;    // Set register c address to rd part of instruction
           regfile_mem_we    = 1'b1;
-          prepost_useincr_o = 1'b0;       // Set to zero to only use alu_operand_a as address (not a+b)
+          prepost_useincr_o = 1'b0; // only use alu_operand_a as address (not a+b)
           alu_op_a_mux_sel_o = OP_A_REGA_OR_FWD;
 
           data_sign_extension_o = 1'b1;
 
-          // Forward AMO instruction code to per2axi
+          // Apply AMO instruction at `atop_o`.
           atop_o = {1'b1, instr_rdata_i[31:27]};
 
           unique case (instr_rdata_i[31:27])
@@ -525,7 +522,7 @@ module riscv_decoder
             AMO_MINU,
             AMO_MAXU: begin
               data_we_o = 1'b1;
-              alu_op_c_mux_sel_o = OP_C_REGB_OR_FWD;  // pass write data through ALU operand c
+              alu_op_c_mux_sel_o = OP_C_REGB_OR_FWD; // pass write data through ALU operand c
             end
             default : illegal_insn_o = 1'b1;
           endcase

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -208,6 +208,9 @@ module riscv_id_stage
     input  logic        data_misaligned_i,
     input  logic        data_err_i,
     output logic        data_err_ack_o,
+
+    output logic [5:0]  atomic_op_ex_o,
+
     // Interrupt signals
     input  logic        irq_i,
     input  logic        irq_sec_i,
@@ -385,6 +388,9 @@ module riscv_id_stage
   logic [1:0]  data_reg_offset_id;
   logic        data_req_id;
   logic        data_load_event_id;
+
+  // Atomic memory instruction
+  logic [5:0]  atomic_op_id;
 
   // hwloop signals
   logic [N_HWLP_BITS-1:0] hwloop_regid, hwloop_regid_int;
@@ -1132,6 +1138,9 @@ module riscv_id_stage
     .data_reg_offset_o               ( data_reg_offset_id        ),
     .data_load_event_o               ( data_load_event_id        ),
 
+    // Atomic memory access
+    .atomic_op_o                     ( atomic_op_id              ),
+
     // hwloop signals
     .hwloop_we_o                     ( hwloop_we_int             ),
     .hwloop_target_mux_sel_o         ( hwloop_target_mux_sel     ),
@@ -1464,6 +1473,7 @@ module riscv_id_stage
       data_reg_offset_ex_o        <= 2'b0;
       data_req_ex_o               <= 1'b0;
       data_load_event_ex_o        <= 1'b0;
+      atomic_op_ex_o              <= 5'b0;
 
       data_misaligned_ex_o        <= 1'b0;
 
@@ -1574,6 +1584,7 @@ module riscv_id_stage
           data_sign_ext_ex_o        <= data_sign_ext_id;
           data_reg_offset_ex_o      <= data_reg_offset_id;
           data_load_event_ex_o      <= data_load_event_id;
+          atomic_op_ex_o            <= atomic_op_id;
         end else begin
           data_load_event_ex_o      <= 1'b0;
         end

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -209,7 +209,7 @@ module riscv_id_stage
     input  logic        data_err_i,
     output logic        data_err_ack_o,
 
-    output logic [5:0]  atomic_op_ex_o,
+    output logic [5:0]  atop_ex_o,
 
     // Interrupt signals
     input  logic        irq_i,
@@ -390,7 +390,7 @@ module riscv_id_stage
   logic        data_load_event_id;
 
   // Atomic memory instruction
-  logic [5:0]  atomic_op_id;
+  logic [5:0]  atop_id;
 
   // hwloop signals
   logic [N_HWLP_BITS-1:0] hwloop_regid, hwloop_regid_int;
@@ -1139,7 +1139,7 @@ module riscv_id_stage
     .data_load_event_o               ( data_load_event_id        ),
 
     // Atomic memory access
-    .atomic_op_o                     ( atomic_op_id              ),
+    .atop_o                          ( atop_id                   ),
 
     // hwloop signals
     .hwloop_we_o                     ( hwloop_we_int             ),
@@ -1473,7 +1473,7 @@ module riscv_id_stage
       data_reg_offset_ex_o        <= 2'b0;
       data_req_ex_o               <= 1'b0;
       data_load_event_ex_o        <= 1'b0;
-      atomic_op_ex_o              <= 5'b0;
+      atop_ex_o                   <= 5'b0;
 
       data_misaligned_ex_o        <= 1'b0;
 
@@ -1584,7 +1584,7 @@ module riscv_id_stage
           data_sign_ext_ex_o        <= data_sign_ext_id;
           data_reg_offset_ex_o      <= data_reg_offset_id;
           data_load_event_ex_o      <= data_load_event_id;
-          atomic_op_ex_o            <= atomic_op_id;
+          atop_ex_o                 <= atop_id;
         end else begin
           data_load_event_ex_o      <= 1'b0;
         end

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -42,6 +42,7 @@ module riscv_id_stage
   parameter N_HWLP            =  2,
   parameter N_HWLP_BITS       =  $clog2(N_HWLP),
   parameter PULP_SECURE       =  0,
+  parameter A_EXTENSION       =  0,
   parameter APU               =  0,
   parameter FPU               =  0,
   parameter Zfinx             =  0,
@@ -1028,6 +1029,7 @@ module riscv_id_stage
 
   riscv_decoder
     #(
+      .A_EXTENSION         ( A_EXTENSION          ),
       .FPU                 ( FPU                  ),
       .FP_DIVSQRT          ( FP_DIVSQRT           ),
       .PULP_SECURE         ( PULP_SECURE          ),

--- a/rtl/riscv_load_store_unit.sv
+++ b/rtl/riscv_load_store_unit.sv
@@ -57,8 +57,8 @@ module riscv_load_store_unit
     input  logic         data_misaligned_ex_i, // misaligned access in last ld/st   -> from ID/EX pipeline
     output logic         data_misaligned_o,    // misaligned access was detected    -> to controller
 
-    input  logic [5:0]   data_atomic_op_i,     // atomic instructions signal        -> from ex stage
-    output logic [5:0]   data_atomic_op_o,     // atomic instruction signal         -> core output
+    input  logic [5:0]   data_atop_ex_i,       // atomic instructions signal        -> from ex stage
+    output logic [5:0]   data_atop_o,          // atomic instruction signal         -> core output
 
     // stall signal
     output logic         lsu_ready_ex_o, // LSU ready for new data in EX stage
@@ -340,14 +340,13 @@ module riscv_load_store_unit
   assign data_addr_o      = data_addr_int;
   assign data_wdata_o     = data_wdata;
   assign data_we_o        = data_we_ex_i;
+  assign data_atop_o      = data_atop_ex_i;
   assign data_be_o        = data_be;
 
   assign misaligned_st    = data_misaligned_ex_i;
 
   assign load_err_o       = data_gnt_i && data_err_i && ~data_we_o;
   assign store_err_o      = data_gnt_i && data_err_i && data_we_o;
-
-  assign data_atomic_op_o = data_atomic_op_i;
 
   // FSM
   always_comb

--- a/rtl/riscv_load_store_unit.sv
+++ b/rtl/riscv_load_store_unit.sv
@@ -57,6 +57,9 @@ module riscv_load_store_unit
     input  logic         data_misaligned_ex_i, // misaligned access in last ld/st   -> from ID/EX pipeline
     output logic         data_misaligned_o,    // misaligned access was detected    -> to controller
 
+    input  logic [5:0]   data_atomic_op_i,     // atomic instructions signal        -> from ex stage
+    output logic [5:0]   data_atomic_op_o,     // atomic instruction signal         -> core output
+
     // stall signal
     output logic         lsu_ready_ex_o, // LSU ready for new data in EX stage
     output logic         lsu_ready_wb_o, // LSU ready for new data in WB stage
@@ -334,12 +337,17 @@ module riscv_load_store_unit
   assign data_rdata_ex_o = (data_rvalid_i == 1'b1) ? data_rdata_ext : rdata_q;
 
   // output to data interface
-  assign data_addr_o   = data_addr_int;
-  assign data_wdata_o  = data_wdata;
-  assign data_we_o     = data_we_ex_i;
-  assign data_be_o     = data_be;
+  assign data_addr_o      = data_addr_int;
+  assign data_wdata_o     = data_wdata;
+  assign data_we_o        = data_we_ex_i;
+  assign data_be_o        = data_be;
 
-  assign misaligned_st = data_misaligned_ex_i;
+  assign misaligned_st    = data_misaligned_ex_i;
+
+  assign load_err_o       = data_gnt_i && data_err_i && ~data_we_o;
+  assign store_err_o      = data_gnt_i && data_err_i && data_we_o;
+
+  assign data_atomic_op_o = data_atomic_op_i;
 
   // FSM
   always_comb

--- a/rtl/riscv_tracer.sv
+++ b/rtl/riscv_tracer.sv
@@ -399,6 +399,20 @@ module riscv_tracer (
       end
     endfunction
 
+    function void printAtomicInstr(input string mnemonic);
+      begin
+        regs_read.push_back('{rs1, rs1_value});
+        regs_read.push_back('{rs2, rs2_value});
+        regs_write.push_back('{rd, 'x});
+        if (instr[31:27] == AMO_LR) begin
+          // Do not print rs2 for load-reserved
+          str = $sformatf("%-16s x%0d, (x%0d)", mnemonic, rd, rs1);
+        end else begin
+          str = $sformatf("%-16s x%0d, x%0d, (x%0d)", mnemonic, rd, rs2, rs1);
+        end
+      end
+    endfunction // printAtomicInstr
+
     function void printLoadInstr();
       string mnemonic;
       logic [2:0] size;
@@ -1005,6 +1019,18 @@ module riscv_tracer (
         INSTR_FCVTSWU:    trace.printIFInstr("fcvt.s.wu");
         INSTR_FMVSX:      trace.printIFInstr("fmv.s.x");
 
+        // RV32A
+        INSTR_LR:         trace.printAtomicInstr("lr.w");
+        INSTR_SC:         trace.printAtomicInstr("sc.w");
+        INSTR_AMOSWAP:    trace.printAtomicInstr("amoswap.w");
+        INSTR_AMOADD:     trace.printAtomicInstr("amoadd.w");
+        INSTR_AMOXOR:     trace.printAtomicInstr("amoxor.w");
+        INSTR_AMOAND:     trace.printAtomicInstr("amoand.w");
+        INSTR_AMOOR:      trace.printAtomicInstr("amoor.w");
+        INSTR_AMOMIN:     trace.printAtomicInstr("amomin.w");
+        INSTR_AMOMAX:     trace.printAtomicInstr("amomax.w");
+        INSTR_AMOMINU:    trace.printAtomicInstr("amominu.w");
+        INSTR_AMOMAXU:    trace.printAtomicInstr("amomaxu.w");
 
         // opcodes with custom decoding
         {25'b?, OPCODE_LOAD}:       trace.printLoadInstr();


### PR DESCRIPTION
This implements RISC-V's 'A' standard extension for atomic instructions by decoding atomic operations and feeding them through to a new `data_atop_o` port.  The tracer has been updated as well.